### PR TITLE
New modifications and the resulting tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Software:
 Hardware:
 - Raspberry Pi 4B
 - Fysetc Spider V1.0 Controller Board
+- TMC2209 Stepper Drivers
 
 Mods/Deviations (W.R.T. Stock V2.4):
 - Raspberry Pi uses a [heatframe](https://smile.amazon.com/gp/product/B085XPHY77) for efficent passive cooling.
 - 12V LED Strips for chamber lighting.
 - Edwardyeeks' [Braced Z Drive Motor/Tensioner](https://github.com/VoronDesign/VoronUsers/tree/master/printer_mods/edwardyeeks/V2.4_z_drive_motor_tensioner_mod)
-- Ellis' [Short Z Joints](https://github.com/VoronDesign/VoronUsers/tree/master/printer_mods/Ellis/Short_Z_Joints)
 - StvPtrsn's [Side Fan Supports w/o Tape](https://github.com/VoronDesign/VoronUsers/tree/master/printer_mods/StvPtrsn/Side_Fan_Support_No_Tape)
-- Changed controller chamber fans to be controlled by each SKR (fans only operate when the drivers are active).
+- Changed controller chamber fans to be controlled (fans only operate when the drivers are active).
 - Cork insulation directly under hotbed to protect electronic chamber from direct/radiated heat.
 - Edwardyeeks' [Purge Bucket and Nozzle cleaner](https://github.com/VoronDesign/VoronUsers/tree/master/printer_mods/edwardyeeks/Decontaminator_Purge_Bucket_&_Nozzle_Scrubber)
 - BadNoob's [**A**fter**B**urner **B**ad**N**oob Version **30**](https://github.com/VoronDesign/VoronUsers/pull/302) (finally released/public)
@@ -24,13 +24,13 @@ Mods/Deviations (W.R.T. Stock V2.4):
 - Hartk's [AB Toolhead PCB](https://github.com/hartk1213/MISC/tree/main/PCBs/Afterburner_Toolhead_PCB)
 - JosAr's [Klicky Probe](https://github.com/VoronDesign/VoronUsers/tree/master/printer_mods/JosAr/Klicky-Probe)
 - ProtoLoft/TitusLabs' [Z Calibration Plugin](https://github.com/protoloft/klipper_z_calibration)
-
-Planned Mods:
 - Hartk's [GE5C Z Bearings](https://github.com/hartk1213/MISC/tree/main/Voron%20Mods/Voron%202/2.4/Voron2.4_GE5C)
 - Hartk's [Pins Mode](https://github.com/hartk1213/MISC/tree/main/Voron%20Mods/Voron%202/2.4/Voron2.4_Pins_Mod)
 - Hartk's [Y Endstop Relocation](https://github.com/hartk1213/MISC/tree/main/Voron%20Mods/Voron%202/2.4/Voron2.4_Y_Endstop_Relocation)
+- Replaced the stock V2 X Carriage Frame w/ the stock V1.8 version (includes X endstop location).
 
 Updates:
+- Replaced all motions parts on the gantry w/ pinned parts. Relocated X/Y Endstops.
 - Rewired entire machine w/ PTFE, added Hartk's Toolhead PCB, replaced Omron Probe w/ Klicky probe.
 - Added code to allow moonraker's Update Manager to pull config changes.
 - Replaced 2x SKR 1.3 controllers with single Fysetc Spider.

--- a/homing.cfg
+++ b/homing.cfg
@@ -2,7 +2,7 @@
 #  Homing definition
 #####################################################################
 [safe_z_home]
-home_xy_position: 227.5,350 ## Update with X,Y location of endstop pin
+home_xy_position: 226,350 ## Update with X,Y location of endstop pin
 speed: 3600 #6000
 z_hop: 15
 z_hop_speed: 6000

--- a/homing.cfg
+++ b/homing.cfg
@@ -2,7 +2,7 @@
 #  Homing definition
 #####################################################################
 [safe_z_home]
-home_xy_position: 230,350 ## Update with X,Y location of endstop pin
+home_xy_position: 227.5,350 ## Update with X,Y location of endstop pin
 speed: 3600 #6000
 z_hop: 15
 z_hop_speed: 6000

--- a/machine.cfg
+++ b/machine.cfg
@@ -287,7 +287,7 @@ heater: heater_bed
 #####################################################################
 
 ##   Chamber Temp Sensor - TE1
-[temperature_sensor chamber]
+[temperature_sensor Chamber]
 sensor_type: NTC 100K beta 3950
 sensor_pin: TEMP_1
 min_temp: 0
@@ -295,7 +295,7 @@ max_temp: 100
 gcode_id: C
 
 ##   Z Extrusion Expansion Sensor - TE2
-[temperature_sensor frame]
+[temperature_sensor Frame]
 sensor_type: EPCOS 100K B57560G104F
 sensor_pin: TEMP_2
 

--- a/probe.cfg
+++ b/probe.cfg
@@ -14,7 +14,7 @@ speed: 4
 lift_speed: 15
 samples: 3
 samples_result: median
-sample_retract_dist: 0.5
+sample_retract_dist: 1.5
 #samples_tolerance: 0.005
 samples_tolerance_retries: 1
 

--- a/probe.cfg
+++ b/probe.cfg
@@ -35,7 +35,7 @@ max_adjust: 10
 
 [z_calibration]
 #   The X and Y coordinates (in mm) for clicking the nozzle on the Z endstop
-probe_nozzle_x: 230 
+probe_nozzle_x: 227.5 
 probe_nozzle_y: 350
 
 #   The X and Y coordinates (in mm) for clicking the probe's switch on the Z endstop

--- a/probe.cfg
+++ b/probe.cfg
@@ -17,6 +17,7 @@ samples_result: median
 sample_retract_dist: 1.5
 #samples_tolerance: 0.005
 samples_tolerance_retries: 1
+drop_first_result: true
 
 [quad_gantry_level]
 gantry_corners:
@@ -35,11 +36,11 @@ max_adjust: 10
 
 [z_calibration]
 #   The X and Y coordinates (in mm) for clicking the nozzle on the Z endstop
-probe_nozzle_x: 227.5 
+probe_nozzle_x: 226 
 probe_nozzle_y: 350
 
 #   The X and Y coordinates (in mm) for clicking the probe's switch on the Z endstop
-probe_switch_x: 224
+probe_switch_x: 223
 probe_switch_y: 328
 
 # position on bed for print surface probing
@@ -154,7 +155,7 @@ variable_home_z_height:         15    # Z when homing
 #dock location
 variable_docklocation_x:        275    # X Dock position
 variable_docklocation_y:        350   # Y Dock position
-variable_docklocation_z:        12    # Z dock position
+variable_docklocation_z:        11    # Z dock position
 variable_dockarmslenght:        30    # Dock arms lenght, toolhead movement necessary to clear the dock arms
 
 

--- a/probe.cfg
+++ b/probe.cfg
@@ -331,9 +331,9 @@ gcode:
         # Drop Probe to Probe location
         G1 X{Dx} Y{Dy} F{Sd}
         # Probe decoupling
-        G1 X{Dx|int + 40} Y{Dy} F{Sr}
+        G1 X{Dx|int - 40} Y{Dy} F{Sr}
         #Go to Z safe distance
-        G1 X{Dx|int + 40} Y{Dy|int - 5} Z{Hzh} F{St}
+        G1 X{Dx|int - 40} Y{Dy|int - 5} Z{Hzh} F{St}
 
 
         CheckProbe action=dock


### PR DESCRIPTION
Replaced the XY Hall Effect endstop w/ two standard Omron switches (via Hartk's Y relocation mod and the V1.8 X Gantry) which caused all the hard set endstop/klicky stuff to change position.